### PR TITLE
Add cli interface

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,10 +1,11 @@
+import argparse
 
 
 def main():
     parser = argparse.ArgumentParser(description='Initialize an Elm page')
 
-    parser.add_argument('module_name')
-    parser.add_argument('destination')
+    parser.add_argument('module_name', help='the component name e.g Some.Module.Name')
+    parser.add_argument('destination', help='the destination folder. Defaults to current', default="./")
     args = parser.parse_args()
 
     bootstrap(args.module_name, args.destination)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,13 @@
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Initialize an Elm page')
+
+    parser.add_argument('module_name')
+    parser.add_argument('destination')
+    args = parser.parse_args()
+
+    bootstrap(args.module_name, args.destination)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Sets up the client interface so that the file can be run as a script

Currently uses non-existent `bootstrap` function to be defined by @joneshf's branch
